### PR TITLE
Add platforms specification for dev container image build

### DIFF
--- a/.github/workflows/prebuild-devcontainer.yml
+++ b/.github/workflows/prebuild-devcontainer.yml
@@ -38,4 +38,5 @@ jobs:
           context: .
           file: .devcontainer/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:devcontainer


### PR DESCRIPTION
Specify target platforms for the dev container image to support both amd64 and arm64 architectures.