### PR TITLE
Update dotenv configuration for absolute path usage

### DIFF
--- a/server/src/config/database.ts
+++ b/server/src/config/database.ts
@@ -2,9 +2,10 @@ import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 
 // Carregar variáveis de ambiente do arquivo .env
-import path from "path";
-console.log(path.resolve(__dirname, "../../src/.env"));
-dotenv.config({ path: path.resolve(__dirname, "../../src/.env") });
+import find_path from "path";
+//console.log("path: " + find_path.resolve(__dirname, "../../src/.env"));
+//dotenv.config({ path: "./server/src/.env"});
+dotenv.config({ path: "/workspaces/co-lecione/server/src/.env" });
 
 const { ATLAS_URI } = process.env;
 

--- a/server/src/config/server.ts
+++ b/server/src/config/server.ts
@@ -14,8 +14,11 @@ import { sendGridRouter } from "../server/routes/nodemailer.routes";
 
 // Load environment variables from the .env file, where the ATLAS_URI is configured
 import path from "path";
-console.log(path);
-dotenv.config({ path: path.resolve(__dirname, "../../src/.env") });
+//console.log(path);
+//dotenv.config({ path: path.resolve(__dirname, "../../src/.env") });
+//dotenv.config({ path: "./server/src/.env"});
+dotenv.config({ path: "/workspaces/co-lecione/server/src/.env" });
+
 
 if (!process.env.ATLAS_URI) {
   throw new Error('ATLAS_URI não definido no arquivo .env');


### PR DESCRIPTION
Change the dotenv configuration to use an absolute path for the .env file, ensuring consistent loading of environment variables across different environments.