### PR TITLE
Update dotenv configuration for relative path usage

### DIFF
--- a/server/src/config/database.ts
+++ b/server/src/config/database.ts
@@ -4,8 +4,8 @@ import dotenv from 'dotenv';
 // Carregar variáveis de ambiente do arquivo .env
 import find_path from "path";
 //console.log("path: " + find_path.resolve(__dirname, "../../src/.env"));
-//dotenv.config({ path: "./server/src/.env"});
-dotenv.config({ path: "/workspaces/co-lecione/server/src/.env" });
+dotenv.config({ path: "./server/src/.env"});
+//dotenv.config({ path: "/workspaces/co-lecione/server/src/.env" }); - doesnt work
 
 const { ATLAS_URI } = process.env;
 

--- a/server/src/config/server.ts
+++ b/server/src/config/server.ts
@@ -16,8 +16,8 @@ import { sendGridRouter } from "../server/routes/nodemailer.routes";
 import path from "path";
 //console.log(path);
 //dotenv.config({ path: path.resolve(__dirname, "../../src/.env") });
-//dotenv.config({ path: "./server/src/.env"});
-dotenv.config({ path: "/workspaces/co-lecione/server/src/.env" });
+dotenv.config({ path: "./server/src/.env"});
+//dotenv.config({ path: "/workspaces/co-lecione/server/src/.env" }); doesnt work
 
 
 if (!process.env.ATLAS_URI) {


### PR DESCRIPTION
Change the dotenv configuration to use a relative path for the .env file, ensuring compatibility across different environments.