### PR TITLE
Remove console log statements in check-files.ts

### DIFF
--- a/server/src/scripts/check-files.ts
+++ b/server/src/scripts/check-files.ts
@@ -3,10 +3,7 @@ import path from "path";
 
 // Define the paths to the required files
 const envFilePath = path.resolve(__dirname, "../.env");
-console.log("envFilePath", envFilePath);
 const x509CertPath = path.resolve(__dirname, "../X509-cert.pem");
-console.log("x509CertPath", x509CertPath);
- // Adjust the path as needed
 
 // Function to check if a file exists
 function checkFileExists(filePath: string, fileName: string) {


### PR DESCRIPTION
Eliminate unnecessary console log statements that output file paths in check-files.ts to clean up the code.